### PR TITLE
Fix YAML example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,5 @@ steps:
   - name: AutoCorrect
     uses: huacnlee/autocorrect-action@main
     with:
-      args:
-        - --lint $(git diff --diff-filter=AM --name-only ${{ github.event.pull_request.base.sha }}}
+      args: --lint $(git diff --diff-filter=AM --name-only ${{ github.event.pull_request.base.sha }}}
 ```


### PR DESCRIPTION
The syntax of YAML in README is invalid, refer to ["Workflow syntax"](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswithargs) for more information.