### PR TITLE
enh:Allow args to specify a custom repo file path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM huacnlee/autocorrect:v2.13.3
 
+WORKDIR ${GITHUB_WORKSPACE}
+
 RUN apk add --update nodejs yarn && \
   curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM huacnlee/autocorrect:latest
+FROM huacnlee/autocorrect:2.14.0
 
 WORKDIR ${GITHUB_WORKSPACE}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@ FROM huacnlee/autocorrect:v2.13.3
 
 WORKDIR ${GITHUB_WORKSPACE}
 
-RUN apk add --no-cache git
-
-RUN git config --global --add safe.directory /github/workspace
-
 RUN apk add --update nodejs yarn && \
   curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,17 @@ FROM huacnlee/autocorrect:v2.13.3
 
 WORKDIR ${GITHUB_WORKSPACE}
 
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apk add --update nodejs yarn && \
   curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 
 ADD ./entrypoint.sh /entrypoint.sh
 RUN yarn config set prefix /root/.yarn && \
   yarn global add autocorrect-node@2.8.4
-
-ENV PATH="/root/.yarn/bin:${PATH}"
+  
+ENV PATH="/root/.yarn/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:${PATH}"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM huacnlee/autocorrect:v2.13.3
+FROM huacnlee/autocorrect:latest
 
 WORKDIR ${GITHUB_WORKSPACE}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR ${GITHUB_WORKSPACE}
 
 RUN apk add --no-cache git
 
+RUN git config --global --add safe.directory /github/workspace
+
 RUN apk add --update nodejs yarn && \
   curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 
@@ -11,6 +13,6 @@ ADD ./entrypoint.sh /entrypoint.sh
 RUN yarn config set prefix /root/.yarn && \
   yarn global add autocorrect-node@2.8.4
   
-ENV PATH="/root/.yarn/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:${PATH}"
+ENV PATH="/root/.yarn/bin:${PATH}"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM huacnlee/autocorrect:v2.13.3
 
+git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
 WORKDIR ${GITHUB_WORKSPACE}
 
 RUN apk add --update nodejs yarn && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM huacnlee/autocorrect:v2.13.3
 
-git config --global --add safe.directory ${GITHUB_WORKSPACE}
-
 WORKDIR ${GITHUB_WORKSPACE}
 
 RUN apk add --update nodejs yarn && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM huacnlee/autocorrect:v2.13.3
 
 WORKDIR ${GITHUB_WORKSPACE}
 
-RUN apt-get update && apt-get install -y \
-    git \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache git
 
 RUN apk add --update nodejs yarn && \
   curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM huacnlee/autocorrect:2.14.0
+FROM huacnlee/autocorrect:v2.14.0
 
 WORKDIR ${GITHUB_WORKSPACE}
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,22 @@ steps:
 ## Enable ReviewDog for Report
 
 ```yml
-steps:
-  - uses: actions/checkout@v4
-  - name: AutoCorrect
-    uses: huacnlee/autocorrect-action@v2
-  - name: Report ReviewDog
-    if: failure()
-    uses: huacnlee/autocorrect-action@v2
-    env:
-      REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      reviewdog: true
+runs-on: ubuntu-latest
+  permissions:
+    pull-requests: write
+  steps:
+    - name: Check repo
+      uses: actions/checkout@v4
+    - name: AutoCorrect
+      uses: huacnlee/autocorrect-action@v2
+    - name: Report ReviewDog
+      if: failure()
+      uses: huacnlee/autocorrect-action@v2
+      env:
+        REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        reviewdog: true
+        args: ./docs/zh/*  ./docs/en/*  # Set the path to your repository files
 ```
 
 <img width="819" alt="image" src="https://github.com/huacnlee/autocorrect-action/assets/5518/050d6f62-d461-44fc-a22f-2fb581ba0912">

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,5 @@
-# action.yml
 name: "AutoCorrect"
-description: "Run AutoCorrect Lint to checking copywriting."
+description: "Run AutoCorrect Lint to check copywriting."
 branding:
   icon: "check"
   color: "gray-dark"
@@ -14,9 +13,10 @@ inputs:
     required: false
     default: "false"
   reviewdog:
-    description: "Enable ReviewDog for report results to Pull Request"
+    description: "Enable ReviewDog to report results to Pull Request"
     required: false
     default: "false"
+
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+echo "Workspace path: ${GITHUB_WORKSPACE}"
+
 bin=/usr/local/bin/autocorrect
 
 # If USE_NPM=true, use npm version of autocorrect

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,6 @@ set -e
 
 bin=/usr/local/bin/autocorrect
 
-
-
 # If USE_NPM=true, use npm version of autocorrect
 if [ "$USE_NPM" = "true" ]; then
     echo "Use autocorrect-node"
@@ -13,7 +11,11 @@ fi
 
 if [ "$REVIEWDOG" = "true" ]; then
     echo "Use reviewdog"
-    $bin --lint . --format rdjson | reviewdog -f=rdjson -reporter=github-pr-review -level=warning
+    args=${ARGS:-"--lint "}
+    cmd="$bin $args --format rdjson $@ | reviewdog -f=rdjson -reporter=github-pr-review -level=warning"
+    echo "Running command: $cmd"
+    # shellcheck disable=SC2086
+    eval "$cmd"
 else
-    $bin $*
+    $bin "$@"
 fi


### PR DESCRIPTION
Allow args to specify a custom repo file path

This PR introduces support for specifying a custom repository file path via the `args` parameter. It enables users to flexibly define the file path they want to operate on, rather than relying on the default `/github/workspace` path.

Key changes include:
- Modified the `entrypoint.sh` script to accept and process a custom repo file path passed through `args`.
- Updated the Dockerfile to ensure environment variables and path configurations support custom paths.
- Added examples in the GitHub Actions workflow file to demonstrate how to pass a custom path using `args`.

These changes enhance flexibility and allow users to run operations smoothly in different workspace structures.